### PR TITLE
fix: Days by weeks

### DIFF
--- a/lib/ex_cycle/validations.ex
+++ b/lib/ex_cycle/validations.ex
@@ -38,8 +38,8 @@ defmodule ExCycle.Validations do
     :minute_of_hour,
     :hour_of_day,
     :days_of_month,
-    :days,
     :interval,
+    :days,
     :excluded_dates
   ]
 
@@ -129,8 +129,13 @@ defmodule ExCycle.Validations do
     end
   end
 
-  defp add_lock(locks, :day, _validations) do
-    [Lock.new(:day) | locks]
+  @exceptions [:days]
+  defp add_lock(locks, :day, validations) do
+    if Enum.any?(validations, &(&1 in @exceptions)) do
+      locks
+    else
+      [Lock.new(:day) | locks]
+    end
   end
 
   defp add_lock(locks, :week_day, _validations) do

--- a/lib/ex_cycle/validations/date_validation.ex
+++ b/lib/ex_cycle/validations/date_validation.ex
@@ -28,6 +28,7 @@ defmodule ExCycle.Validations.DateValidation do
     ExCycle.State.update_next(state, fn next ->
       next
       |> Date.end_of_month()
+      |> Date.add(1)
       |> NaiveDateTime.new!(NaiveDateTime.to_time(next))
     end)
   end

--- a/lib/ex_cycle/validations/lock.ex
+++ b/lib/ex_cycle/validations/lock.ex
@@ -46,12 +46,18 @@ defmodule ExCycle.Validations.Lock do
   end
 
   def next(state, %Lock{unit: :day}) do
-    shift_years = state.next.year + div(state.next.month, 12)
-    shift_months = rem(state.next.month, 12) + 1
+    if state.origin.day > state.next.day do
+      ExCycle.State.update_next(state, fn next ->
+        %{next | day: state.origin.day}
+      end)
+    else
+      shift_years = state.next.year + div(state.next.month, 12)
+      shift_months = rem(state.next.month, 12) + 1
 
-    ExCycle.State.update_next(state, fn next ->
-      %{next | year: shift_years, month: shift_months, day: state.origin.day}
-    end)
+      ExCycle.State.update_next(state, fn next ->
+        %{next | year: shift_years, month: shift_months, day: state.origin.day}
+      end)
+    end
   end
 
   def next(state, %Lock{unit: :month}) do

--- a/test/ex_cycle/rule_test.exs
+++ b/test/ex_cycle/rule_test.exs
@@ -20,7 +20,7 @@ defmodule ExCycle.RuleTest do
   end
 
   describe "next/1" do
-    test "daily" do
+    test "daily at 20 and 10" do
       rule =
         Rule.new(:daily, interval: 2, hours: [20, 10])
         |> Map.put(:state, ExCycle.State.new(~D[2024-04-04]))
@@ -38,79 +38,68 @@ defmodule ExCycle.RuleTest do
       assert rule.state.next == ~N[2024-04-06 20:00:00]
     end
 
+    test "daily" do
+      rule = Rule.new(:daily, interval: 2) |> Rule.init(~D[2024-04-04])
+      assert rule.state.next == ~N[2024-04-04 00:00:00]
+
+      rule = Rule.next(rule)
+      assert rule.state.next == ~N[2024-04-06 00:00:00]
+
+      rule = Rule.next(rule)
+      assert rule.state.next == ~N[2024-04-08 00:00:00]
+
+      rule = Rule.next(rule)
+      assert rule.state.next == ~N[2024-04-10 00:00:00]
+    end
+
     test "weekly" do
-      rule =
-        Rule.new(:weekly, interval: 2, hours: [20, 10])
-        |> Map.put(:state, ExCycle.State.new(~D[2024-04-04]))
+      rule = Rule.new(:weekly, interval: 2) |> Rule.init(~D[2024-04-04])
+      assert rule.state.next == ~N[2024-04-04 00:00:00]
 
       rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-04-04 10:00:00]
+      assert rule.state.next == ~N[2024-04-18 00:00:00]
 
       rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-04-04 20:00:00]
-
-      rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-04-18 10:00:00]
-
-      rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-04-18 20:00:00]
+      assert rule.state.next == ~N[2024-05-02 00:00:00]
     end
 
     test "monthly" do
-      rule =
-        Rule.new(:monthly, interval: 2, hours: [20, 10])
-        |> Map.put(:state, ExCycle.State.new(~D[2024-04-30]))
+      rule = Rule.new(:monthly, interval: 2) |> Rule.init(~D[2024-04-30])
+      assert rule.state.next == ~N[2024-04-30 00:00:00]
 
       rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-04-30 10:00:00]
+      assert rule.state.next == ~N[2024-06-30 00:00:00]
 
       rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-04-30 20:00:00]
+      assert rule.state.next == ~N[2024-08-30 00:00:00]
 
       rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-06-30 10:00:00]
-
-      rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-06-30 20:00:00]
+      assert rule.state.next == ~N[2024-10-30 00:00:00]
     end
 
     test "monthly with leap month" do
-      rule =
-        Rule.new(:monthly, interval: 1, hours: [20, 10])
-        |> Map.put(:state, ExCycle.State.new(~D[2024-01-30]))
-
-      rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-01-30 10:00:00]
-
-      rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-01-30 20:00:00]
+      rule = Rule.new(:monthly, interval: 1) |> Rule.init(~D[2024-01-30])
+      assert rule.state.next == ~N[2024-01-30 00:00:00]
 
       # NOTE: February is skipped because it's an invalid date
       # See [RFC 5545](https://www.rfc-editor.org/rfc/rfc5545) page 42
 
       rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-03-30 10:00:00]
+      assert rule.state.next == ~N[2024-03-30 00:00:00]
 
       rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-03-30 20:00:00]
+      assert rule.state.next == ~N[2024-04-30 00:00:00]
     end
 
     test "yearly with leap year" do
-      rule =
-        Rule.new(:yearly, interval: 2, hours: [20, 10])
-        |> Map.put(:state, ExCycle.State.new(~D[2024-02-29]))
+      rule = Rule.new(:yearly, interval: 2) |> Rule.init(~D[2024-02-29])
+      assert rule.state.next == ~N[2024-02-29 00:00:00]
 
       rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-02-29 10:00:00]
+      assert rule.state.next == ~N[2028-02-29 00:00:00]
 
       rule = Rule.next(rule)
-      assert rule.state.next == ~N[2024-02-29 20:00:00]
-
-      rule = Rule.next(rule)
-      assert rule.state.next == ~N[2028-02-29 10:00:00]
-
-      rule = Rule.next(rule)
-      assert rule.state.next == ~N[2028-02-29 20:00:00]
+      assert rule.state.next == ~N[2032-02-29 00:00:00]
     end
   end
 end

--- a/test/ex_cycle/validations/interval_test.exs
+++ b/test/ex_cycle/validations/interval_test.exs
@@ -6,7 +6,8 @@ defmodule ExCycle.Validations.IntervalTest do
   @moduletag origin: ~N[2024-04-04 00:00:00]
   @moduletag next: ~N[2024-04-04 00:00:00]
   setup %{origin: origin, next: next} do
-    %{state: ExCycle.State.new(origin, next)}
+    {:ok, state} = ExCycle.State.new(origin, next) |> ExCycle.State.set_result()
+    %{state: state}
   end
 
   @moduletag interval_value: 1
@@ -225,11 +226,11 @@ defmodule ExCycle.Validations.IntervalTest do
     end
 
     @tag interval_value: 2
-    @tag origin: ~D[2024-11-04]
-    @tag next: ~D[2024-11-04]
+    @tag origin: ~D[2024-11-01]
+    @tag next: ~D[2024-11-01]
     test "with year shifting", %{state: state, interval: interval} do
       state = Interval.next(state, interval)
-      assert state.next == ~N[2025-01-04 00:00:00]
+      assert state.next == ~N[2025-01-01 00:00:00]
     end
   end
 


### PR DESCRIPTION
We have an invalid behaviour where `-1` act as if the day is present in the last week. However the rule MUST BE `the last x of the month`.

- `{-1, :monday}` is now the last monday of the month
- `{-2, :monday}` is now the 2nd last monday of the month

I had to change the order of validation execution to execute `interval` before `days`. This could lead to some breaking change because the `monthly` interval will be executed BEFORE any days validation (and this is the correct behaviour)