### PR TITLE
fix: none duration

### DIFF
--- a/lib/ex_cycle/rule.ex
+++ b/lib/ex_cycle/rule.ex
@@ -85,8 +85,20 @@ defmodule ExCycle.Rule do
       validations: Validations.build(frequency, opts),
       count: count,
       until: until,
-      duration: duration
+      duration: if(valid_duration?(duration), do: duration)
     }
+  end
+
+  defp valid_duration?(duration) do
+    case duration do
+      %Duration{} ->
+        duration
+        |> Map.take([:week, :day, :hour, :minute, :second])
+        |> Enum.any?(fn {_unit, value} -> value != 0 end)
+
+      _ ->
+        false
+    end
   end
 
   @doc """

--- a/test/ex_cycle/rule_test.exs
+++ b/test/ex_cycle/rule_test.exs
@@ -4,8 +4,8 @@ defmodule ExCycle.RuleTest do
   alias ExCycle.Rule
 
   describe "new/2" do
-    test "build rule for: daily at hours [10, 20]" do
-      rule = Rule.new(:daily, interval: 2, hours: [20, 10])
+    test "build rule for: daily at hours [10, 20] for 1h" do
+      rule = Rule.new(:daily, interval: 2, hours: [20, 10], duration: %Duration{hour: 1})
 
       expected_validations = [
         %ExCycle.Validations.HourOfDay{hours: [10, 20]},
@@ -16,6 +16,12 @@ defmodule ExCycle.RuleTest do
       ]
 
       assert rule.validations == expected_validations
+      assert rule.duration == %Duration{hour: 1}
+    end
+
+    test "zero duration is removed" do
+      rule = Rule.new(:daily, duration: %Duration{})
+      assert is_nil(rule.duration)
     end
   end
 


### PR DESCRIPTION
If the duration is equal to zero (no hour, no minute ...) then simply remove it.

A duration of 0 caused an infinite loop with timezone. Because on timezone if the `span.from == span.to` the occurrence is skipped.