### PR TITLE
fix: days validations

### DIFF
--- a/lib/ex_cycle/validations/days_of_month.ex
+++ b/lib/ex_cycle/validations/days_of_month.ex
@@ -45,6 +45,8 @@ defmodule ExCycle.Validations.DaysOfMonth do
 
       ExCycle.State.update_next(state, fn next ->
         %{next | year: shift_years, month: shift_months, day: next_day}
+        |> NaiveDateTime.to_date()
+        |> NaiveDateTime.new!(~T[00:00:00])
       end)
     else
       ExCycle.State.update_next(state, fn next ->

--- a/test/ex_cycle/validations/days_of_month_test.exs
+++ b/test/ex_cycle/validations/days_of_month_test.exs
@@ -21,6 +21,12 @@ defmodule ExCycle.Validations.DaysOfMonthTest do
   end
 
   describe "next/2" do
+    test "next should reset the time", %{state: state} do
+      validation = DaysOfMonth.new([20])
+      new_state = DaysOfMonth.next(state, validation)
+      assert NaiveDateTime.to_time(new_state.next) == ~T[00:00:00]
+    end
+
     test "next day of same month", %{state: state} do
       validation = DaysOfMonth.new([20])
       new_state = DaysOfMonth.next(state, validation)

--- a/test/ex_cycle/validations/days_test.exs
+++ b/test/ex_cycle/validations/days_test.exs
@@ -67,6 +67,13 @@ defmodule ExCycle.Validations.DaysTest do
   end
 
   describe "next/2" do
+    @tag datetime: ~N[2024-04-30 10:00:00]
+    test "next should reset the time", %{state: state} do
+      validation = Days.new([:monday])
+      new_state = Days.next(state, validation)
+      assert NaiveDateTime.to_time(new_state.next) == ~T[00:00:00]
+    end
+
     test "next day of same month", %{state: state} do
       validation = Days.new([:monday])
       new_state = Days.next(state, validation)


### PR DESCRIPTION
When days validation is used with hour validations, we could face an infinite loop. The days validation used the origin time. So every time we switch to another day, the time was reset to the origin time.

But if the origin hour was higher than the rule hour, the hour validation add 1 more day to match the rule hour.

And this create an infinite loop for the following rule starting at any hour higher than 10:

```
Every Saturday at 10:00AM
```