### PR TITLE
Fix rule starts_at

### DIFF
--- a/lib/ex_cycle/rule.ex
+++ b/lib/ex_cycle/rule.ex
@@ -117,8 +117,13 @@ defmodule ExCycle.Rule do
   def init(rule, from) do
     rule
     |> Map.update!(:state, fn state ->
-      (state || ExCycle.State.new(from))
-      |> ExCycle.State.set_next(from)
+      state = state || ExCycle.State.new(from)
+
+      if Date.compare(state.next, from) == :lt do
+        ExCycle.State.set_next(state, from)
+      else
+        state
+      end
       |> do_next(rule.validations)
     end)
     |> generate_result()

--- a/test/ex_cycle_test.exs
+++ b/test/ex_cycle_test.exs
@@ -44,6 +44,16 @@ defmodule ExCycleTest do
                ~N[2024-03-04 10:00:00]
              ]
     end
+
+    test "rule starts_at must be used instead of occurrence starts_at" do
+      datetimes =
+        ExCycle.new()
+        |> ExCycle.add_rule(:daily, starts_at: ~D[2024-01-02])
+        |> ExCycle.occurrences(~D[2024-01-01])
+        |> Enum.take(2)
+
+      assert datetimes == [~N[2024-01-02 00:00:00], ~N[2024-01-03 00:00:00]]
+    end
   end
 
   describe "excluded dates" do


### PR DESCRIPTION
If a rule have a starts_at higher than the occurrence starts_at, the rule state MUST used its starts_at instead of the occurrence starts_at.

Closes https://github.com/Omerlo-Technologies/ex_cycle/issues/19