### PR TITLE
Fix weekly option with no result set on state

### DIFF
--- a/lib/ex_cycle/validations/interval.ex
+++ b/lib/ex_cycle/validations/interval.ex
@@ -100,10 +100,14 @@ defmodule ExCycle.Validations.Interval do
   end
 
   def next(state, %Interval{frequency: :weekly, value: value}) do
-    origin_week = Date.beginning_of_week(state.next)
-    next_week = Date.beginning_of_week(state.result)
+    {origin_week, next_week} =
+      if is_nil(state.result) do
+        {Date.beginning_of_week(state.origin), Date.beginning_of_week(state.next)}
+      else
+        {Date.beginning_of_week(state.next), Date.beginning_of_week(state.result)}
+      end
 
-    if origin_week == next_week do
+    if origin_week == next_week && not is_nil(state.result) do
       ExCycle.State.update_next(state, &NaiveDateTime.add(&1, value * 7, :day))
     else
       diff = rem(Date.diff(next_week, origin_week), value * 7)

--- a/test/ex_cycle/validations/interval_test.exs
+++ b/test/ex_cycle/validations/interval_test.exs
@@ -5,9 +5,16 @@ defmodule ExCycle.Validations.IntervalTest do
 
   @moduletag origin: ~N[2024-04-04 00:00:00]
   @moduletag next: ~N[2024-04-04 00:00:00]
-  setup %{origin: origin, next: next} do
-    {:ok, state} = ExCycle.State.new(origin, next) |> ExCycle.State.set_result()
-    %{state: state}
+  @moduletag set_result?: true
+  setup %{origin: origin, next: next, set_result?: set_result?} do
+    state = ExCycle.State.new(origin, next)
+
+    if set_result? do
+      {:ok, state} = ExCycle.State.set_result(state)
+      %{state: state}
+    else
+      %{state: state}
+    end
   end
 
   @moduletag interval_value: 1
@@ -213,6 +220,15 @@ defmodule ExCycle.Validations.IntervalTest do
     test "with year shifting", %{state: state, interval: interval} do
       state = Interval.next(state, interval)
       assert Date.diff(state.next, state.origin) == 14
+    end
+
+    @tag origin: ~D[2024-09-01]
+    @tag next: ~D[2024-09-02]
+    @tag interval_value: 2
+    @tag set_result?: false
+    test "weekly without result", %{state: state, interval: interval} do
+      state = Interval.next(state, interval)
+      assert state.next == ~N[2024-09-09 00:00:00]
     end
   end
 


### PR DESCRIPTION
Part of https://github.com/Omerlo-Technologies/ex_cycle/issues/23 to fix the runtime error caused by no result set on the state