### PR TITLE
Add option to define the week_starting_on

### DIFF
--- a/lib/ex_cycle.ex
+++ b/lib/ex_cycle.ex
@@ -53,6 +53,15 @@ defmodule ExCycle do
   @doc """
   Creates a stream of occurrences using the `from` as reference.
 
+  ## Options
+
+  - `week_starting_on`: This option defines which day is considered the first day of the week.
+    It is used in functions like day_of_week(date, week_starting_on) to adjust how intervals are
+    calculated for recurrence rules.
+    By default, the week starts on `:default` (which is monday according to
+    [Date.day_of_week/2](https://hexdocs.pm/elixir/Date.html#day_of_week/2), but you can customize
+    this to match your application's needs or user preferences.
+
   ## Examples
 
       iex> cycle =
@@ -74,11 +83,12 @@ defmodule ExCycle do
       ]
 
   """
-  @spec occurrences(t(), datetime()) :: Enumerable.t(NaiveDateTime.t() | ExCycle.Span.t())
-  def occurrences(%ExCycle{} = cycle, from) do
+  @spec occurrences(t(), datetime(), keyword()) ::
+          Enumerable.t(NaiveDateTime.t() | ExCycle.Span.t())
+  def occurrences(%ExCycle{} = cycle, from, opts \\ []) do
     cycle
     |> Map.update!(:rules, fn rules ->
-      Enum.map(rules, &Rule.init(&1, from))
+      Enum.map(rules, &Rule.init(&1, from, opts))
     end)
     |> Stream.unfold(&get_next_occurrence/1)
   end

--- a/lib/ex_cycle/rule.ex
+++ b/lib/ex_cycle/rule.ex
@@ -113,8 +113,10 @@ defmodule ExCycle.Rule do
       %ExCycle{}
 
   """
-  @spec init(t(), ExCycle.datetime()) :: t()
-  def init(rule, from) do
+  @spec init(t(), ExCycle.datetime(), keyword()) :: t()
+  def init(rule, from, opts \\ []) do
+    week_starting_on = Keyword.get(opts, :week_starting_on, :default)
+
     rule
     |> Map.update!(:state, fn state ->
       state = state || ExCycle.State.new(from)
@@ -124,6 +126,7 @@ defmodule ExCycle.Rule do
       else
         state
       end
+      |> ExCycle.State.set_week_starting_on(week_starting_on)
       |> do_next(rule.validations)
     end)
     |> generate_result()

--- a/lib/ex_cycle/state.ex
+++ b/lib/ex_cycle/state.ex
@@ -10,10 +10,11 @@ defmodule ExCycle.State do
           next: NaiveDateTime.t(),
           result: DateTime.t() | NaiveDateTime.t() | ExCycle.Span.t() | nil,
           exhausted?: boolean(),
-          iteration: non_neg_integer()
+          iteration: non_neg_integer(),
+          week_starting_on: :default | atom()
         }
 
-  defstruct [:origin, :next, :result, exhausted?: false, iteration: 0]
+  defstruct [:origin, :next, :result, exhausted?: false, iteration: 0, week_starting_on: :default]
 
   @type datetime :: Date.t() | DateTime.t() | NaiveDateTime.t()
 
@@ -83,8 +84,14 @@ defmodule ExCycle.State do
     Map.update!(datetime_state, :next, fun)
   end
 
+  @spec set_next(t(), NaiveDateTime.t()) :: t()
   def set_next(state, datetime) do
     %{state | next: to_naive(datetime)}
+  end
+
+  @spec set_week_starting_on(t(), :default | atom()) :: t()
+  def set_week_starting_on(state, week_starting_on) do
+    %{state | week_starting_on: week_starting_on}
   end
 
   def set_result(state) do

--- a/lib/ex_cycle/validations/interval.ex
+++ b/lib/ex_cycle/validations/interval.ex
@@ -55,8 +55,8 @@ defmodule ExCycle.Validations.Interval do
   end
 
   def valid?(state, %{frequency: :weekly, value: value}) do
-    origin_week = Date.beginning_of_week(state.origin)
-    next_week = Date.beginning_of_week(state.next)
+    origin_week = Date.beginning_of_week(state.origin, state.week_starting_on)
+    next_week = Date.beginning_of_week(state.next, state.week_starting_on)
     diff = Date.diff(next_week, origin_week)
     rem(diff, value * 7) == 0
   end
@@ -102,9 +102,11 @@ defmodule ExCycle.Validations.Interval do
   def next(state, %Interval{frequency: :weekly, value: value}) do
     {origin_week, next_week} =
       if is_nil(state.result) do
-        {Date.beginning_of_week(state.origin), Date.beginning_of_week(state.next)}
+        {Date.beginning_of_week(state.origin),
+         Date.beginning_of_week(state.next, state.week_starting_on)}
       else
-        {Date.beginning_of_week(state.next), Date.beginning_of_week(state.result)}
+        {Date.beginning_of_week(state.next),
+         Date.beginning_of_week(state.result, state.week_starting_on)}
       end
 
     if origin_week == next_week && not is_nil(state.result) do


### PR DESCRIPTION
This PR is need because American and some Middle East Calendar (and some religious calendars) starts their weeks on `sunday` instead of `monday`

Related issue: https://github.com/Omerlo-Technologies/ex_cycle/issues/23