### PR TITLE
fix: locks order

### DIFF
--- a/lib/ex_cycle/validations.ex
+++ b/lib/ex_cycle/validations.ex
@@ -53,7 +53,7 @@ defmodule ExCycle.Validations do
   @spec build(Interval.frequency(), keyword()) :: [any_validation(), ...]
   def build(frequency, opts) do
     validations = Enum.reduce(opts, %{}, &build_validation/2)
-    locks = locks_for(frequency, Map.keys(validations))
+    locks = locks_for(frequency, Map.keys(validations)) |> Enum.reverse()
     sort(validations) ++ locks
   end
 
@@ -61,8 +61,9 @@ defmodule ExCycle.Validations do
     add_lock(:second, validations)
     |> add_lock(:minute, validations)
     |> add_lock(:hour, validations)
-    |> add_lock(:day, validations)
+    # Month MUST be before day because month doesn't have same max day (30, 31 ...)
     |> add_lock(:month, validations)
+    |> add_lock(:day, validations)
   end
 
   defp locks_for(:monthly, validations) do

--- a/test/ex_cycle/rule_test.exs
+++ b/test/ex_cycle/rule_test.exs
@@ -10,8 +10,8 @@ defmodule ExCycle.RuleTest do
       expected_validations = [
         %ExCycle.Validations.HourOfDay{hours: [10, 20]},
         %ExCycle.Validations.Interval{frequency: :daily, value: 2},
-        %ExCycle.Validations.Lock{unit: :minute},
-        %ExCycle.Validations.Lock{unit: :second}
+        %ExCycle.Validations.Lock{unit: :second},
+        %ExCycle.Validations.Lock{unit: :minute}
       ]
 
       assert rule.validations == expected_validations

--- a/test/ex_cycle_test.exs
+++ b/test/ex_cycle_test.exs
@@ -340,4 +340,16 @@ defmodule ExCycleTest do
              ]
     end
   end
+
+  describe "locks" do
+    test "locks order for first datetime" do
+      datetime =
+        ExCycle.new()
+        |> ExCycle.add_rule(:daily, timezone: "Etc/UTC", starts_at: ~N[2024-01-01 10:00:00])
+        |> ExCycle.occurrences(~N[2024-10-16 10:01:01])
+        |> Enum.at(0)
+
+      assert datetime == ~U[2024-10-17 10:00:00Z]
+    end
+  end
 end


### PR DESCRIPTION
When `second`, `minutes` and `hours` are not the same value, we bump the day everytime because thoses validations were executed AFTER the day lock.