### PR TITLE
fix: `occurrences` that use NaiveDateTime or DateTime

### DIFF
--- a/lib/ex_cycle/rule.ex
+++ b/lib/ex_cycle/rule.ex
@@ -119,13 +119,8 @@ defmodule ExCycle.Rule do
 
     rule
     |> Map.update!(:state, fn state ->
-      state = state || ExCycle.State.new(from)
-
-      if Date.compare(state.next, from) == :lt do
-        ExCycle.State.set_next(state, from)
-      else
-        state
-      end
+      (state || ExCycle.State.new(from))
+      |> ExCycle.State.init(from)
       |> ExCycle.State.set_week_starting_on(week_starting_on)
       |> do_next(rule.validations)
     end)

--- a/test/ex_cycle/validations/interval_test.exs
+++ b/test/ex_cycle/validations/interval_test.exs
@@ -7,7 +7,7 @@ defmodule ExCycle.Validations.IntervalTest do
   @moduletag next: ~N[2024-04-04 00:00:00]
   @moduletag set_result?: true
   setup %{origin: origin, next: next, set_result?: set_result?} do
-    state = ExCycle.State.new(origin, next)
+    state = ExCycle.State.new(origin) |> ExCycle.State.init(next)
 
     if set_result? do
       {:ok, state} = ExCycle.State.set_result(state)

--- a/test/ex_cycle_test.exs
+++ b/test/ex_cycle_test.exs
@@ -295,6 +295,16 @@ defmodule ExCycleTest do
 
       assert datetimes == [~N[2024-01-03 10:00:00], ~N[2024-01-05 10:00:00]]
     end
+
+    test "next is override with the occurrences" do
+      datetimes =
+        ExCycle.new()
+        |> ExCycle.add_rule(:daily, interval: 2, hours: [10], starts_at: ~D[2024-01-01])
+        |> ExCycle.occurrences(~N[2024-01-01 10:01:01])
+        |> Enum.take(2)
+
+      assert datetimes == [~N[2024-01-03 10:00:00], ~N[2024-01-05 10:00:00]]
+    end
   end
 
   describe "with DaysOfMonth" do


### PR DESCRIPTION
We used `Date.compare/2` to check if the specified datetime given to `occurrences` happen after the `starts_at`. This caused error for the following code

```elixir
ExCycle.new()
|> ExCycle.add_rule(:daily, starts_at: ~N[2024-01-01 10:00:00])
|> ExCycle.occurrences(~U[2024-01-01 11:01:01Z])
```

This didn't bump the `next` to `~N[2024-01-01 11:01:01Z]` because it's the same `Date` as `~N[2024-01-01 10:00:00]`.