### PR TITLE
fix: Stringify function should not join list items

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,16 @@ stringify = fn(field, msg_opts) ->
 
   case field do
     :interval -> msg
-    :times -> " at " <> msg
-    :minutes -> " every hours at minutes " <> msg
-    :days_of_month -> ", on the " <> msg
-    :days -> " on " <> msg
+    :times -> "at " <> msg
+    :minutes -> "every hours at minutes " <> msg
+    :days_of_month -> "on the " <> msg
+    :days -> "on " <> msg
   end
 end
 
 ExCycle.Rule.new(:weekly, days: [:monday], hours: [10], minutes: [30])
-|> StringBuilder.traverse_validations(stringify)
+|> ExCycle.StringBuilder.traverse_validations(stringify)
+|> Enum.join(" ")
 
 # "daily at 10:00, 10:30"
 ```

--- a/lib/ex_cycle/string_builder.ex
+++ b/lib/ex_cycle/string_builder.ex
@@ -6,6 +6,7 @@ defmodule ExCycle.StringBuilder do
 
       iex> ExCycle.Rule.new(:weekly, days: [:monday], hours: [10], minutes: [30])
       ...> StringBuilder.traverse_validations(&stringify/2)
+      ...> Enum.join(" ")
       "daily at 10:00, 10:30"
 
   > NOTE: You **MUST** implement the stringify function on your side.
@@ -35,7 +36,7 @@ defmodule ExCycle.StringBuilder do
     |> put_days(params)
     |> put_days_of_month(params)
     |> put_interval(params)
-    |> Enum.map_join(fn {unit, msg_opts} -> msg_fun.(unit, msg_opts) end)
+    |> Enum.map(fn {unit, msg_opts} -> msg_fun.(unit, msg_opts) end)
   end
 
   defp put_interval(acc, params) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExCycle.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.8.1"
 
   def project do
     [

--- a/test/ex_cycle/string_builder_test.exs
+++ b/test/ex_cycle/string_builder_test.exs
@@ -5,31 +5,31 @@ defmodule ExCycle.StringBuilderTest do
 
   test "every 2 days at 10:00" do
     rule = ExCycle.Rule.new(:daily, interval: 2, hours: [10])
-    string = StringBuilder.traverse_validations(rule, &stringify/2)
+    string = StringBuilder.traverse_validations(rule, &stringify/2) |> Enum.join(" ")
     assert string == "every 2 days at 10:00"
   end
 
   test "daily at 10:00, 10:30" do
     rule = ExCycle.Rule.new(:daily, hours: [10], minutes: [0, 30])
-    string = StringBuilder.traverse_validations(rule, &stringify/2)
+    string = StringBuilder.traverse_validations(rule, &stringify/2) |> Enum.join(" ")
     assert string == "daily at 10:00, 10:30"
   end
 
   test "weekly every hours at minutes 0, 30" do
     rule = ExCycle.Rule.new(:weekly, minutes: [0, 30])
-    string = StringBuilder.traverse_validations(rule, &stringify/2)
+    string = StringBuilder.traverse_validations(rule, &stringify/2) |> Enum.join(" ")
     assert string == "weekly every hours at minutes 0, 30"
   end
 
   test "monthly, on the 1st, 30" do
     rule = ExCycle.Rule.new(:monthly, days_of_month: [1, 30])
-    string = StringBuilder.traverse_validations(rule, &stringify/2)
-    assert string == "monthly, on the 1st, 30th"
+    string = StringBuilder.traverse_validations(rule, &stringify/2) |> Enum.join(" ")
+    assert string == "monthly on the 1st, 30th"
   end
 
   test "weekly on monday at 10:30" do
     rule = ExCycle.Rule.new(:weekly, days: [:monday], hours: [10], minutes: [30])
-    string = StringBuilder.traverse_validations(rule, &stringify/2)
+    string = StringBuilder.traverse_validations(rule, &stringify/2) |> Enum.join(" ")
     assert string == "weekly on monday at 10:30"
   end
 
@@ -43,10 +43,10 @@ defmodule ExCycle.StringBuilderTest do
 
     case field do
       :interval -> msg
-      :times -> " at " <> msg
-      :minutes -> " every hours at minutes " <> msg
-      :days_of_month -> ", on the " <> msg
-      :days -> " on " <> msg
+      :times -> "at " <> msg
+      :minutes -> "every hours at minutes " <> msg
+      :days_of_month -> "on the " <> msg
+      :days -> "on " <> msg
     end
   end
 end


### PR DESCRIPTION
After using it on our CMS I foud the `Enum.map_join/2` too restrictive. I think it’s better to return a simple list and let the developper defined how the final string must be composed.