### PR TITLE
fix: Monthly interval

### DIFF
--- a/lib/ex_cycle/validations/interval.ex
+++ b/lib/ex_cycle/validations/interval.ex
@@ -108,6 +108,9 @@ defmodule ExCycle.Validations.Interval do
   end
 
   def next(state, %Interval{frequency: :monthly, value: value}) do
+    diff = state.origin.month - (state.next.month + 12)
+    value = value + rem(diff, value)
+
     months = value + state.next.month - 1
     shift_years = state.next.year + div(months, 12)
     shift_months = rem(months, 12) + 1

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExCycle.MixProject do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.8.2"
 
   def project do
     [

--- a/test/ex_cycle_test.exs
+++ b/test/ex_cycle_test.exs
@@ -323,6 +323,27 @@ defmodule ExCycleTest do
                ~N[2024-03-01 10:00:00]
              ]
     end
+
+    test "every 2 months" do
+      opts = [
+        interval: 2,
+        start_at_date: ~N[2025-05-19 06:15:00],
+        days: [{4, :monday}],
+        count: 3
+      ]
+
+      datetimes =
+        ExCycle.new()
+        |> ExCycle.add_rule(:monthly, opts)
+        |> ExCycle.occurrences(~D[2025-05-19])
+        |> Enum.take(3)
+
+      assert datetimes == [
+               ~N[2025-05-26 00:00:00],
+               ~N[2025-07-28 00:00:00],
+               ~N[2025-09-22 00:00:00]
+             ]
+    end
   end
 
   describe "days" do


### PR DESCRIPTION
We used the value for every X months to bump the month by the value. 

However if the month is shift by any others validation we continue to shift the same amount +X months. Instead we should use a relative shift.

Let’s say we have `Every 2 months on the first Monday starting on 2025-05-19`

1. I switch to 1st Monday -> 2025-06-02
2. Not every 2 months -> 2025-08-01 (not every 2 months)

Instead it should shift to to `2025-07-01`